### PR TITLE
[feat] 포인트 서비스 로직 및 단위 테스트 추가

### DIFF
--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -1,0 +1,84 @@
+package io.hhplus.tdd.point;
+
+import io.hhplus.tdd.database.PointHistoryTable;
+import io.hhplus.tdd.database.UserPointTable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Service
+public class PointService {
+
+    private final UserPointTable userPointTable;
+    private final PointHistoryTable pointHistoryTable;
+
+    // 유저별 직렬화를 위한 공정 락 캐시
+    private final ConcurrentHashMap<Long, ReentrantLock> locks = new ConcurrentHashMap<>();
+
+    public PointService(UserPointTable userPointTable, PointHistoryTable pointHistoryTable) {
+        this.userPointTable = userPointTable;
+        this.pointHistoryTable = pointHistoryTable;
+    }
+
+    public UserPoint get(long userId) {
+        return userPointTable.selectById(userId);
+    }
+
+    public List<PointHistory> histories(long userId) {
+        return pointHistoryTable.selectAllByUserId(userId);
+    }
+
+    public UserPoint charge(long userId, long amount) {
+        validateAmount(amount);
+        ReentrantLock lock = lockFor(userId);
+        lock.lock();
+        try {
+            UserPoint current = userPointTable.selectById(userId);
+            if (willOverflow(current.point(), amount)) {
+                throw new IllegalArgumentException("허용 범위를 초과합니다.");
+            }
+            long newPoint = current.point() + amount;
+            UserPoint updated = userPointTable.insertOrUpdate(userId, newPoint);
+            pointHistoryTable.insert(userId, amount, TransactionType.CHARGE, System.currentTimeMillis());
+            return updated;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public UserPoint use(long userId, long amount) {
+        validateAmount(amount);
+        ReentrantLock lock = lockFor(userId);
+        lock.lock();
+        try {
+            UserPoint current = userPointTable.selectById(userId);
+            if (current.point() < amount) {
+                throw new IllegalStateException("잔액 부족");
+            }
+            long newPoint = current.point() - amount;
+            UserPoint updated = userPointTable.insertOrUpdate(userId, newPoint);
+            pointHistoryTable.insert(userId, amount, TransactionType.USE, System.currentTimeMillis());
+            return updated;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // 공정 락: 대기 순서대로 lock 획득 → 기아 방지
+    private ReentrantLock lockFor(long userId) {
+        return locks.computeIfAbsent(userId, id -> new ReentrantLock(true));
+    }
+
+    private void validateAmount(long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("금액은 0보다 큰 정수여야 합니다.");
+        }
+    }
+
+    // 오버플로우 & 언더플로우 방지
+    private boolean willOverflow(long a, long b) {
+        return (b > 0 && a > Long.MAX_VALUE - b) || (b < 0 && a < Long.MIN_VALUE - b);
+    }
+}

--- a/src/test/java/io/hhplus/tdd/PointServiceUnitTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceUnitTest.java
@@ -24,22 +24,63 @@ class PointServiceUnitTest {
 
     @BeforeEach
     void setUp() {
+        // Given
         userPointTable = mock(UserPointTable.class);
         pointHistoryTable = mock(PointHistoryTable.class);
         pointService = new PointService(userPointTable, pointHistoryTable);
+        // Then: PointService가 정상 생성됨
     }
 
+    // 정상 케이스 (충전)
+    @Test
+    @DisplayName("정상적으로 포인트를 충전하면 잔액이 증가한다")
+    void givenValidAmount_whenCharge_thenBalanceIncreases() {
+        // Given
+        long userId = 1L;
+        when(userPointTable.selectById(userId))
+                .thenReturn(new UserPoint(userId, 0L, System.currentTimeMillis()));
+        when(userPointTable.insertOrUpdate(userId, 100L))
+                .thenReturn(new UserPoint(userId, 100L, System.currentTimeMillis()));
+
+        // When
+        UserPoint result = pointService.charge(userId, 100L);
+
+        // Then
+        assertThat(result.point()).isEqualTo(100L);
+        verify(pointHistoryTable).insert(eq(userId), eq(100L), eq(TransactionType.CHARGE), anyLong());
+    }
+
+    // 정상 케이스 (사용)
+    @Test
+    @DisplayName("정상적으로 포인트를 사용하면 잔액이 차감된다")
+    void givenEnoughBalance_whenUse_thenBalanceDecreases() {
+        // Given
+        long userId = 1L;
+        when(userPointTable.selectById(userId))
+                .thenReturn(new UserPoint(userId, 200L, System.currentTimeMillis()));
+        when(userPointTable.insertOrUpdate(userId, 100L))
+                .thenReturn(new UserPoint(userId, 100L, System.currentTimeMillis()));
+
+        // When
+        UserPoint result = pointService.use(userId, 100L);
+
+        // Then
+        assertThat(result.point()).isEqualTo(100L);
+        verify(pointHistoryTable).insert(eq(userId), eq(100L), eq(TransactionType.USE), anyLong());
+    }
+
+    // 정상 케이스 (누적)
     @Test
     @DisplayName("동일 금액 반복 충전 시 잔액이 누적된다")
     void charge_repeatedSameAmount_accumulatesCorrectly() {
         long userId = 1L;
         long[] balance = {0L}; // <-- Mock 내부 상태
 
-        // selectById는 현재 balance를 반영
+        // Given: selectById는 현재 balance를 반영
         when(userPointTable.selectById(userId))
                 .thenAnswer(inv -> new UserPoint(userId, balance[0], System.currentTimeMillis()));
 
-        // insertOrUpdate가 호출될 때 balance를 갱신
+        // And: insertOrUpdate가 호출될 때 balance를 갱신
         when(userPointTable.insertOrUpdate(eq(userId), anyLong()))
                 .thenAnswer(inv -> {
                     balance[0] = inv.getArgument(1, Long.class);
@@ -50,12 +91,14 @@ class PointServiceUnitTest {
         long amount = 100L;
         long expected = 0;
 
+        // When & Then: 반복 충전 시 누적값 검증
         for (int i = 0; i < repeats; i++) {
             expected += amount;
             UserPoint updated = pointService.charge(userId, amount);
             assertThat(updated.point()).isEqualTo(expected);
         }
 
+        // Then: 히스토리/저장 호출 횟수 검증
         verify(pointHistoryTable, times(repeats))
                 .insert(eq(userId), eq(amount), eq(TransactionType.CHARGE), anyLong());
         verify(userPointTable, times(repeats)).insertOrUpdate(eq(userId), anyLong());
@@ -64,15 +107,22 @@ class PointServiceUnitTest {
     @Test
     @DisplayName("음수 금액 사용 시 400(IllegalArgumentException) 발생")
     void use_negativeAmount_throwsException() {
-        assertThatThrownBy(() -> pointService.use(1L, -100L))
+        // Given
+        long userId = 1L;
+
+        // When & Then
+        assertThatThrownBy(() -> pointService.use(userId, -100L))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("금액은 0보다 큰 정수여야 합니다.");
+
+        // Then: 저장 계층이 호출되지 않아야 함
         verifyNoInteractions(userPointTable, pointHistoryTable);
     }
 
     @Test
     @DisplayName("잔액 최대치 근처에서 사용 시 정상 차감된다")
     void use_nearMaxValue_succeeds() {
+        // Given
         long userId = 1L;
         long nearMax = Long.MAX_VALUE - 10;
         when(userPointTable.selectById(userId))
@@ -80,8 +130,10 @@ class PointServiceUnitTest {
         when(userPointTable.insertOrUpdate(userId, nearMax - 100))
                 .thenReturn(new UserPoint(userId, nearMax - 100, System.currentTimeMillis()));
 
+        // When
         UserPoint result = pointService.use(userId, 100L);
 
+        // Then
         assertThat(result.point()).isEqualTo(nearMax - 100);
         verify(pointHistoryTable).insert(eq(userId), eq(100L), eq(TransactionType.USE), anyLong());
     }
@@ -89,15 +141,18 @@ class PointServiceUnitTest {
     @Test
     @DisplayName("충전 시 오버플로우가 발생하면 예외를 던진다")
     void charge_overflow_throws() {
+        // Given
         long userId = 1L;
         long almostMax = Long.MAX_VALUE - 5;
         when(userPointTable.selectById(userId))
                 .thenReturn(new UserPoint(userId, almostMax, System.currentTimeMillis()));
 
+        // When & Then
         assertThatThrownBy(() -> pointService.charge(userId, 10L))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("허용 범위를 초과합니다.");
 
+        // Then: 저장 계층이 호출되지 않아야 함
         verify(userPointTable, never()).insertOrUpdate(anyLong(), anyLong());
         verify(pointHistoryTable, never()).insert(anyLong(), anyLong(), any(), anyLong());
     }
@@ -105,14 +160,17 @@ class PointServiceUnitTest {
     @Test
     @DisplayName("잔액 부족 시 사용 실패")
     void use_insufficientBalance_throws() {
+        // Given
         long userId = 1L;
         when(userPointTable.selectById(userId))
                 .thenReturn(new UserPoint(userId, 50L, System.currentTimeMillis()));
 
+        // When & Then
         assertThatThrownBy(() -> pointService.use(userId, 100L))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("잔액 부족");
 
+        // Then
         verify(userPointTable, never()).insertOrUpdate(anyLong(), anyLong());
         verify(pointHistoryTable, never()).insert(anyLong(), anyLong(), any(), anyLong());
     }
@@ -120,10 +178,13 @@ class PointServiceUnitTest {
     @Test
     @DisplayName("히스토리 조회: 빈 리스트면 그대로 빈 리스트 반환")
     void histories_emptyList_returnsEmpty() {
+        // Given
         when(pointHistoryTable.selectAllByUserId(99L)).thenReturn(List.of());
 
+        // When
         List<PointHistory> result = pointService.histories(99L);
 
+        // Then
         assertThat(result).isEmpty();
         verify(pointHistoryTable).selectAllByUserId(99L);
     }
@@ -131,10 +192,13 @@ class PointServiceUnitTest {
     @Test
     @DisplayName("없는 사용자 포인트 조회 시 null 그대로 전달")
     void get_nonExistingUser_returnsNull() {
+        // Given
         when(userPointTable.selectById(123L)).thenReturn(null);
 
+        // When
         UserPoint result = pointService.get(123L);
 
+        // Then
         assertThat(result).isNull();
         verify(userPointTable).selectById(123L);
     }

--- a/src/test/java/io/hhplus/tdd/PointServiceUnitTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceUnitTest.java
@@ -1,0 +1,141 @@
+package io.hhplus.tdd;
+
+import io.hhplus.tdd.database.PointHistoryTable;
+import io.hhplus.tdd.database.UserPointTable;
+import io.hhplus.tdd.point.PointHistory;
+import io.hhplus.tdd.point.PointService;
+import io.hhplus.tdd.point.TransactionType;
+import io.hhplus.tdd.point.UserPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class PointServiceUnitTest {
+
+    private UserPointTable userPointTable;
+    private PointHistoryTable pointHistoryTable;
+    private PointService pointService;
+
+    @BeforeEach
+    void setUp() {
+        userPointTable = mock(UserPointTable.class);
+        pointHistoryTable = mock(PointHistoryTable.class);
+        pointService = new PointService(userPointTable, pointHistoryTable);
+    }
+
+    @Test
+    @DisplayName("동일 금액 반복 충전 시 잔액이 누적된다")
+    void charge_repeatedSameAmount_accumulatesCorrectly() {
+        long userId = 1L;
+        long[] balance = {0L}; // <-- Mock 내부 상태
+
+        // selectById는 현재 balance를 반영
+        when(userPointTable.selectById(userId))
+                .thenAnswer(inv -> new UserPoint(userId, balance[0], System.currentTimeMillis()));
+
+        // insertOrUpdate가 호출될 때 balance를 갱신
+        when(userPointTable.insertOrUpdate(eq(userId), anyLong()))
+                .thenAnswer(inv -> {
+                    balance[0] = inv.getArgument(1, Long.class);
+                    return new UserPoint(userId, balance[0], System.currentTimeMillis());
+                });
+
+        int repeats = 5;
+        long amount = 100L;
+        long expected = 0;
+
+        for (int i = 0; i < repeats; i++) {
+            expected += amount;
+            UserPoint updated = pointService.charge(userId, amount);
+            assertThat(updated.point()).isEqualTo(expected);
+        }
+
+        verify(pointHistoryTable, times(repeats))
+                .insert(eq(userId), eq(amount), eq(TransactionType.CHARGE), anyLong());
+        verify(userPointTable, times(repeats)).insertOrUpdate(eq(userId), anyLong());
+    }
+
+    @Test
+    @DisplayName("음수 금액 사용 시 400(IllegalArgumentException) 발생")
+    void use_negativeAmount_throwsException() {
+        assertThatThrownBy(() -> pointService.use(1L, -100L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("금액은 0보다 큰 정수여야 합니다.");
+        verifyNoInteractions(userPointTable, pointHistoryTable);
+    }
+
+    @Test
+    @DisplayName("잔액 최대치 근처에서 사용 시 정상 차감된다")
+    void use_nearMaxValue_succeeds() {
+        long userId = 1L;
+        long nearMax = Long.MAX_VALUE - 10;
+        when(userPointTable.selectById(userId))
+                .thenReturn(new UserPoint(userId, nearMax, System.currentTimeMillis()));
+        when(userPointTable.insertOrUpdate(userId, nearMax - 100))
+                .thenReturn(new UserPoint(userId, nearMax - 100, System.currentTimeMillis()));
+
+        UserPoint result = pointService.use(userId, 100L);
+
+        assertThat(result.point()).isEqualTo(nearMax - 100);
+        verify(pointHistoryTable).insert(eq(userId), eq(100L), eq(TransactionType.USE), anyLong());
+    }
+
+    @Test
+    @DisplayName("충전 시 오버플로우가 발생하면 예외를 던진다")
+    void charge_overflow_throws() {
+        long userId = 1L;
+        long almostMax = Long.MAX_VALUE - 5;
+        when(userPointTable.selectById(userId))
+                .thenReturn(new UserPoint(userId, almostMax, System.currentTimeMillis()));
+
+        assertThatThrownBy(() -> pointService.charge(userId, 10L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("허용 범위를 초과합니다.");
+
+        verify(userPointTable, never()).insertOrUpdate(anyLong(), anyLong());
+        verify(pointHistoryTable, never()).insert(anyLong(), anyLong(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("잔액 부족 시 사용 실패")
+    void use_insufficientBalance_throws() {
+        long userId = 1L;
+        when(userPointTable.selectById(userId))
+                .thenReturn(new UserPoint(userId, 50L, System.currentTimeMillis()));
+
+        assertThatThrownBy(() -> pointService.use(userId, 100L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("잔액 부족");
+
+        verify(userPointTable, never()).insertOrUpdate(anyLong(), anyLong());
+        verify(pointHistoryTable, never()).insert(anyLong(), anyLong(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("히스토리 조회: 빈 리스트면 그대로 빈 리스트 반환")
+    void histories_emptyList_returnsEmpty() {
+        when(pointHistoryTable.selectAllByUserId(99L)).thenReturn(List.of());
+
+        List<PointHistory> result = pointService.histories(99L);
+
+        assertThat(result).isEmpty();
+        verify(pointHistoryTable).selectAllByUserId(99L);
+    }
+
+    @Test
+    @DisplayName("없는 사용자 포인트 조회 시 null 그대로 전달")
+    void get_nonExistingUser_returnsNull() {
+        when(userPointTable.selectById(123L)).thenReturn(null);
+
+        UserPoint result = pointService.get(123L);
+
+        assertThat(result).isNull();
+        verify(userPointTable).selectById(123L);
+    }
+}


### PR DESCRIPTION
### **커밋 설명**
서비스 로직 구현 : da8cd7a

서비스 단위 테스트 추가 : 2e24c06

---
### **리뷰 받고 싶은 내용(질문)**
- 커밋: 포인트 서비스 로직 구현 da8cd7a
charge() 메서드에서 음수 금액을 처리하는 방식이 예외로 던지는 게 적절한지 궁금합니다.

- 커밋: 포인트 서비스 단위 테스트 추가 2e24c06
테스트 케이스가 충분히 경계 조건을 커버하는지 확인 부탁드립니다.
JUnit/Mockito 사용 방식 중 개선할 부분이 있는지도 궁금합니다.

---

### **과제 셀프 피드백**
PointService 로직을 구현하면서 충전(charge)과 사용(use) 메서드의 책임 분리를 명확히 하려고 했으나, 예외 처리 로직을 어디까지 서비스 계층에서 맡아야 하는지 고민이 있었습니다.

### 기술적 성장
PointService를 작성하면서 서비스 계층에서 도메인 로직과 예외 처리 분리에 대해 다시 생각하게 되었습니다. 단순히 기능 구현이 아니라, 유지보수하기 좋은 구조를 고민하는 계기가 되었습니다.